### PR TITLE
Install Terraform for the generate step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@v3
       - run: go generate ./...
       - name: git diff
         run: |


### PR DESCRIPTION
This should fix the failing tests in:
- https://github.com/pulumi/terraform-provider-xyz/pull/55
- https://github.com/pulumi/terraform-provider-xyz/pull/54

This was caused by GitHub upgrading the version of linux they were using for default runners.